### PR TITLE
Use built-in http client instead of apache's

### DIFF
--- a/src/main/java/com/langrsoft/util/HttpImpl.java
+++ b/src/main/java/com/langrsoft/util/HttpImpl.java
@@ -1,22 +1,24 @@
 package com.langrsoft.util;
 
 // START:HttpImpl
-import java.io.*;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.util.*;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandlers;
 
-public class HttpImpl implements Http {
-   public String get(String url) {
-      var client = HttpClients.createDefault();
-      var request = new HttpGet(url);
+class HttpImpl implements Http {
+
+  public String get(String url) {
+    try (var client = HttpClient.newHttpClient()) {
+      var request = HttpRequest.newBuilder().uri(URI.create(url)).build();
       try {
-         try (var response = client.execute(request)) {
-             return EntityUtils.toString(response.getEntity());
-         }
-      } catch (IOException e) {
-         throw new RuntimeException(e);
+        var httpResponse = client.send(request, BodyHandlers.ofString());
+        return httpResponse.body();
+      } catch (IOException | InterruptedException e) {
+        throw new RuntimeException(e);
       }
-   }
+    }
+  }
 }
 // END:HttpImpl


### PR DESCRIPTION
just a proposal, then there is one less external dependency. Even though I assume the API of apache's http client is stable enough that it also won't change for a long time when people read the book.

JDK's new HttpClient was introduced in JDK 11